### PR TITLE
Add option wkWindowStatus for wkhtmltopdf option --window-status

### DIFF
--- a/src/Yesod/Content/PDF.hs
+++ b/src/Yesod/Content/PDF.hs
@@ -23,6 +23,7 @@ module Yesod.Content.PDF
   , wkMarginTop
   , wkZoom
   , wkJavascriptDelay
+  , wkWindowStatus
   , PageSize(..)
   , Orientation(..)
   , UnitReal(..)
@@ -118,6 +119,8 @@ data WkhtmltopdfOptions =
       -- ^ Zoom factor.
     , wkJavascriptDelay :: Maybe Int
       -- ^ Time to wait for Javascript to finish in milliseconds.
+    , wkWindowStatus    :: Maybe String
+      -- ^ String to wait for window.status to be set to.
     } deriving (Eq, Ord, Show)
 
 instance Default WkhtmltopdfOptions where
@@ -135,6 +138,7 @@ instance Default WkhtmltopdfOptions where
     , wkMarginTop       = Mm 10
     , wkZoom            = 1
     , wkJavascriptDelay = Nothing
+    , wkWindowStatus    = Nothing
     }
 
 -- | Cf. 'wkPageSize'.
@@ -176,6 +180,7 @@ instance ToArgs WkhtmltopdfOptions where
        , toArgs (wkOrientation opts)
        , maybe [] (\t -> ["--title",            t     ]) (wkTitle           opts)
        , maybe [] (\d -> ["--javascript-delay", show d]) (wkJavascriptDelay opts)
+       , maybe [] (\s -> ["--window-status",    s     ]) (wkWindowStatus    opts)
        , "--margin-bottom" : toArgs (wkMarginBottom opts)
        , "--margin-left"   : toArgs (wkMarginLeft   opts)
        , "--margin-right"  : toArgs (wkMarginRight  opts)


### PR DESCRIPTION
Running `wkhtmltopdf` with `--window-status <text>` causes `wkhtmltopdf` to wait until `window.status` has been set to the value of `<text>` to start rendering.

We're using `--window-status` so we can tell when MathJax is finished typesetting some HTML without using a hardcoded delay:

``` javascript
MathJax.Hub.Queue(function() {
  window.status = "FinishedTypesetting";
});
```

This patch just adds `wkWindowStatus :: Maybe String` to `WkhtmltopdfOptions`. I've tested this with `wkhtmltopdf` versions `0.12.1` and `0.12.2.1`.
