### PR TITLE
Use readCreateProcess, not createProcess

### DIFF
--- a/src/Yesod/Content/PDF.hs
+++ b/src/Yesod/Content/PDF.hs
@@ -84,8 +84,7 @@ wkhtmltopdf opts setupInput =
     hClose tempOutputHandle
     setupInput $ \inputArg -> do
       let args = toArgs opts ++ [inputArg, tempOutputFp]
-      (_, _, _, pHandle) <- createProcess (proc "wkhtmltopdf" args)
-      _ <- waitForProcess pHandle
+      _ <- readCreateProcess (proc "wkhtmltopdf" args) ""
       PDF <$> Data.ByteString.readFile tempOutputFp
 
 -- | Options passed to wkhtmltopdf.  Please use the 'def' value


### PR DESCRIPTION
This ensures the process is bracketed via [withCreateProcess][1] and cleaned up
properly if the calling thread is killed. Another option is to use
withCreateProcess directly, but using the higher-level function and discarding
the stdout result seemed simpler.

In our case, if PDF generation takes too long and the web request times out,
the wkhtmltopdf process would be left as a zombie. Our hope is using a function
that cleans up properly in the face of killed threads will prevent that.

[1]: http://hackage.haskell.org/package/process-1.6.1.0/docs/System-Process.html#v:withCreateProcess