### PR TITLE
FIX: select the correct record for "wkDisableSmartShrinking" option

### DIFF
--- a/src/Yesod/Content/PDF.hs
+++ b/src/Yesod/Content/PDF.hs
@@ -180,7 +180,7 @@ instance ToArgs WkhtmltopdfOptions where
       Prelude.concat
        [ [ "--grayscale"  | True <- [wkGrayscale  opts] ]
        , [ "--lowquality" | True <- [wkLowQuality opts] ]
-       , [ "--disable-smart-shrinking" | True <- [wkLowQuality opts] ]
+       , [ "--disable-smart-shrinking" | True <- [wkDisableSmartShrinking opts] ]
        , toArgs (wkPageSize    opts)
        , toArgs (wkOrientation opts)
        , maybe [] (\t -> ["--title",            t     ]) (wkTitle           opts)


### PR DESCRIPTION
I've just noticed I messed with the record selection for the "wkDisableSmartShrinking" option in #9.

This PR fixes the problem. Sorry about that.